### PR TITLE
Specifying TestFile in PackageInfo.g

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -84,7 +84,7 @@ AvailabilityTest := function()
         return true;
     end,
 
-#TODO TestFile := "tst/testall.g",
+TestFile := "tst/testall.g",
 
 Keywords := [ "Simplicial" ],
 


### PR DESCRIPTION
test.all in the tst directory is now specified as the test file in PackageInfo.g